### PR TITLE
Added Base64 support for communicating with Palworld Server Rcon with…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,24 @@
 # PalWorld Networking
 PalWorld implemention of RCON in C#
 
-## Installation
-You can install [this package](https://www.nuget.org/packages/PalWorld.Networking) with any Nuget package manager:
+## About this Repo
+This repository is a fork of the official PalWorld Networking library, with a new feature to encode/decode Base64 messages with the server. 
+
+This resolves the RCON from breaking when a player joins with a multi-byte character in their name like a symbol, causing the RCON to no longer respond. See more details [here](https://tech.palworldgame.com/api/rcon/).
+
+
+## Requirements
+This implementation requires **Palguard** to be installed on your Palworld server and Base64 enabled. You can get a copy by visiting the official Palguard Discord from this [page](https://github.com/Ultimeit/palguard_anticheat).
+
+### Enabling Base64 Encoding/Decoding in Palguard
+To enable Base64 encoding/decoding, edit the palguard.json file and set the RCONbase64 to true. This will allow the server to encode/decode messages between the RCON and clients after a reboot or running the "__/reloadcfg__" command to apply right away.
+
+```json
+{
+    "RCONbase64": true,
+    "adminIPs": [],
+    ...
 ```
-PM> Install-Package PalWorld.Networking
-```
-It targets .net standard 2.1 from version 1.0.2+ so you can use it in .net framework or .net 5+
 
 ## Usage
 Define an RconClient with the host, port and admin password of your server:
@@ -18,8 +30,8 @@ var host = "192.168.1.69";
 var port = 25575;
 var pass = "S0mep4ssw0rd$"; //This should be the "Admin Password" not the server password
 
-//Create your client (PersistentRconClient's will attempt to reconnect if they get disconnected!)
-IPersistentRconClient client = new PersistentRconClient(host, port, pass);
+//Create your client with base64 mode enabled. (PersistentRconClient's will attempt to reconnect if they get disconnected!)
+IPersistentRconClient client = new PersistentRconClient(host, port, pass, useBase64: true);
 
 //These aren't necessary, they are just helpful for logging!
 client.OnConnected += () => Console.WriteLine("Hello world! I'm connected!");
@@ -48,4 +60,4 @@ await client.SendBroadcast("Hello world!"); //Spaces will be substituted with un
 ```
 
 ## Questions? Comments? Concerns?
-Open up an issue on this repo, or you can contact me via my [discord server](https://discord.gg/6H2eQAzcEj)
+Open up an issue on this repo, or you can contact the official creator's [discord server](https://discord.gg/6H2eQAzcEj)

--- a/src/PalWorld.Networking/Extensions.cs
+++ b/src/PalWorld.Networking/Extensions.cs
@@ -21,7 +21,19 @@ public static class Extensions
         throw new TimeoutException();
     }
 
-    public static string ToBase64(this string str, string content, Encoding encoding) => Convert.ToBase64String(encoding.GetBytes(content));
+    /// <summary>
+    /// Converts the given string to a base64 string
+    /// </summary>
+    /// <param name="stringToEncode">The string to convert to base64</param>
+    /// <param name="encoding">Encoding used while converting</param>
+    /// <returns>A base64 encoded string</returns>
+    public static string ToBase64(this string stringToEncode, Encoding encoding) => Convert.ToBase64String(encoding.GetBytes(stringToEncode));
 
-    public static string FromBase64(this string str, Encoding encoding) => encoding.GetString(Convert.FromBase64String(str));
+    /// <summary>
+    /// Converts the given base64 string to a normal string
+    /// </summary>
+    /// <param name="stringToDecode">The string to convert from base64</param>
+    /// <param name="encoding">Encoding used while converting</param>
+    /// <returns>A normal string</returns>
+    public static string FromBase64(this string stringToDecode, Encoding encoding) => encoding.GetString(Convert.FromBase64String(stringToDecode));
 }

--- a/src/PalWorld.Networking/Extensions.cs
+++ b/src/PalWorld.Networking/Extensions.cs
@@ -20,4 +20,8 @@ public static class Extensions
 
         throw new TimeoutException();
     }
+
+    public static string ToBase64(this string str, string content, Encoding encoding) => Convert.ToBase64String(encoding.GetBytes(content));
+
+    public static string FromBase64(this string str, Encoding encoding) => encoding.GetString(Convert.FromBase64String(str));
 }

--- a/src/PalWorld.Networking/Extensions.cs
+++ b/src/PalWorld.Networking/Extensions.cs
@@ -21,7 +21,19 @@ public static class Extensions
         throw new TimeoutException();
     }
 
-    public static string ToBase64(this string str, string content, Encoding encoding) => Convert.ToBase64String(encoding.GetBytes(content));
+    /// <summary>
+    /// Converts the given string to a base64 string
+    /// </summary>
+    /// <param name="stringToEncode">The string to convert to base64</param>
+    /// <param name="encoding">Encoding used while converting</param>
+    /// <returns>A base64 encoded string</returns>
+    public static string ToBase64(this string stringToEncode, Encoding encoding) => Convert.ToBase64String(encoding.GetBytes(stringToEncode));
 
-    public static string FromBase64(this string str, Encoding encoding) => encoding.GetString(Convert.FromBase64String(str));
+    /// <summary>
+    /// Converts the given base64 string to a normal string
+    /// </summary>
+    /// <param name="stringToDecode">The string to convert from base64</param>
+    /// <param name="encoding">Encoding used while converting</param>
+    /// <returns>A normal string</returns>
+    public static string FromBase64(this string stringToDecode, Encoding encoding) => encoding.GetString(Convert.FromBase64String(str));
 }

--- a/src/PalWorld.Networking/PacketHandler.cs
+++ b/src/PalWorld.Networking/PacketHandler.cs
@@ -40,7 +40,7 @@ internal class PacketHandler(Encoding _encoding, bool _useBase64) : IPacketHandl
 
         // If we're using base64, encode the content. Authentication packets are excluded since Palguard does not interfere with the authentication handshake.
         if (_useBase64 && packet.Type != RconPacketType.Authentication)
-            packet.Content = packet.Content.ToBase64(packet.Content, _encoding);
+            packet.Content = packet.Content.ToBase64(_encoding);
 
         var data = indicators.Concat(_encoding.GetBytes(packet.Content + '\0'))
             .ToArray();

--- a/src/PalWorld.Networking/PalWorld.Networking.csproj
+++ b/src/PalWorld.Networking/PalWorld.Networking.csproj
@@ -12,7 +12,7 @@
 		<RepositoryUrl>https://github.com/calico-crusade/palworld-rcon-sharp</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>PalWorld;RCON;CardboardBox;Cardboard;Pokemon;</PackageTags>
-		<Version>1.0.2</Version>
+		<Version>1.0.3</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<LangVersion>latest</LangVersion>

--- a/src/PalWorld.Networking/PersistentRconClient.cs
+++ b/src/PalWorld.Networking/PersistentRconClient.cs
@@ -22,13 +22,15 @@ public interface IPersistentRconClient : IRconSender
 /// <param name="timeoutSec">How long to wait before considering a command ignored</param>
 /// <param name="maxRetries">How many times to attempt to connect before considering the server dead</param>
 /// <param name="encoding">The encoding to use for the packet body content</param>
+/// <param name="useBase64">Whether or not to encode & decode Base64 messages with the server</param>
 public class PersistentRconClient(
     string host, 
     int port, 
     string password, 
     int timeoutSec = 20,
     int maxRetries = 3,
-    Encoding? encoding = null) : IPersistentRconClient
+    Encoding? encoding = null,
+    bool useBase64 = false) : IPersistentRconClient
 {
     /// <summary>
     /// Triggered when an unhandled exception occurs
@@ -54,6 +56,11 @@ public class PersistentRconClient(
     /// Whether or not the client is ready to send packets
     /// </summary>
     public bool Ready => _client?.Ready ?? false;
+
+    /// <summary>
+    /// Whether or not the client is encoding & decoding Base64 messages with the server.
+    /// </summary>
+    public bool UseBase64 => _client?.UseBase64 ?? false;
 
     /// <summary>
     /// Ensure the client is ready and then send a packet once it is.
@@ -129,7 +136,7 @@ public class PersistentRconClient(
             return new(_client, true);
 
         _client?.Dispose();
-        _client = new RconClient(host, port, password, timeoutSec, encoding);
+        _client = new RconClient(host, port, password, timeoutSec, encoding, useBase64);
         _client.OnConnected += () => OnConnected();
         _client.OnDisconnected += () => OnDisconnected();
         _client.OnError += (ex, note) => OnError(ex, note);

--- a/src/PalWorld.Networking/RconClient.cs
+++ b/src/PalWorld.Networking/RconClient.cs
@@ -116,6 +116,11 @@ public class RconClient : IRconClient
     /// How long to wait before considering a command ignored
     /// </summary>
     private readonly int _cmdTimeoutSec;
+
+    /// <summary>
+    /// Should the client encode & decode Base64 messages with the server
+    /// </summary>
+    private readonly bool _useBase64;
     #endregion
 
     #region Properties
@@ -143,6 +148,11 @@ public class RconClient : IRconClient
     /// Whether or not the client is connected and authenticated with the server
     /// </summary>
     public bool Ready => Connected && Authenticated;
+
+    /// <summary>
+    /// Whether or not the client is encoding & decoding Base64 messages with the server.
+    /// </summary>
+    public bool UseBase64 => _useBase64;
     #endregion
 
     /// <summary>
@@ -153,7 +163,8 @@ public class RconClient : IRconClient
     /// <param name="password">The Admin password for the server</param>
     /// <param name="cmdTimeoutSec">How long to wait before considering a command ignored</param>
     /// <param name="encoder">The encoding to use for the packet body content</param>
-    public RconClient(string host, int port, string password, int cmdTimeoutSec = 20, Encoding? encoder = null)
+    /// <param name="useBase64">Whether or not to encode & decode Base64 messages with the server</param>
+    public RconClient(string host, int port, string password, int cmdTimeoutSec = 20, Encoding? encoder = null, bool useBase64 = false)
     {
         _password = password;
         _cmdTimeoutSec = cmdTimeoutSec;
@@ -161,8 +172,8 @@ public class RconClient : IRconClient
         _client.OnDisconnected += (_) => Disconnected();
         _client.OnException += (e, n) => OnError(e, n);
         _client.OnDataReceived += (_, d) => ReadData(d);
-
-        _handler = new PacketHandler(encoder ?? _defaultEncoding);
+        _useBase64 = useBase64;
+        _handler = new PacketHandler(encoder ?? _defaultEncoding, _useBase64);
         _handler.OnPacketReceived += HandlePacket;
 
         _queue = new();


### PR DESCRIPTION
Adds support for base64 encoding & decoding messages to/from server with Palguard Base64 encoding support added.

I use this library with the base64 implementation to prevent my server manager from losing connection when someone with a multi-byte character joins.

You can pull chunks from the readme for explanation and improve it if you'd like. Tested locally and is working great for me. I am using the UTF-8 encoding, I have not tested with other encoders.