### PR TITLE
Adding Base64 encoding support for PalGuard (issue #2)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,6 @@ name: CI
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PalWorld Networking
-PalWorld implemention of RCON in C#
+PalWorld implementation of RCON in C#
 
 ## Installation
 You can install [this package](https://www.nuget.org/packages/PalWorld.Networking) with any Nuget package manager:
@@ -9,7 +9,7 @@ PM> Install-Package PalWorld.Networking
 It targets .net standard 2.1 from version 1.0.2+ so you can use it in .net framework or .net 5+
 
 ## Usage
-Define an RconClient with the host, port and admin password of your server:
+Define an `RconClient` (or `PersistentRconClient`) with the host, port and admin password of your server:
 
 ```csharp
 using PalWorld.Networking;
@@ -45,6 +45,27 @@ Console.WriteLine($"Server {info?.Name} is on version {info?.Version}");
 
 //You can also send other commands like:
 await client.SendBroadcast("Hello world!"); //Spaces will be substituted with underscores (palworld issue)
+```
+
+## Unicode character support
+PalWorld currently has an issue with Unicode/Multi-byte characters with their RCON implementation. 
+This results in packets that return these characters to hang and timeout when sending or receiving them. 
+You can read more about the issue [here](https://tech.palworldgame.com/api/rcon/#about-multi-byte-characters-in-usernames-letters) or [here](https://github.com/calico-crusade/palworld-rcon-sharp/issues/2).
+
+There is a mod for dedicated servers (currently only supports windows) that fixes this issue: PalGuard ([NexusMods](https://www.nexusmods.com/palworld/mods/451) or [GitHub](https://github.com/Ultimeit/palguard_anticheat)).
+To enable base64 support in this library you will need to override the `encoder` parameter on the `RconClient` or `PersistentRconClient` constructors:
+```csharp
+using PalWorld.Networking;
+
+var host = "192.168.1.69";
+var port = 25575;
+var pass = "S0mep4ssw0rd$";
+var encoding = PalEncoders.Base64;
+
+//Regular client
+var client = new RconClient(host, port, pass, encoder: encoding);
+//Persistent client
+var persistentClient = new PersistentRconClient(host, port, pass, encoder: encoding);
 ```
 
 ## Questions? Comments? Concerns?

--- a/src/PalWorld.Networking/Encoders/Base64EncoderService.cs
+++ b/src/PalWorld.Networking/Encoders/Base64EncoderService.cs
@@ -1,0 +1,39 @@
+﻿namespace PalWorld.Networking;
+
+/// <summary>
+/// Represents a service that can encode and decode packet data using Base64
+/// </summary>
+public class Base64EncoderService : IEncoderService
+{
+    /// <summary>
+    /// Encodes the given data into a byte array
+    /// </summary>
+    /// <param name="data">The data to be encoded</param>
+    /// <returns>The encoded data</returns>
+    public byte[] GetBytes(string data)
+    {
+        return Convert.FromBase64String(data);
+    }
+
+    /// <summary>
+    /// Decodes the given data from a byte array
+    /// </summary>
+    /// <param name="data">The data to decode</param>
+    /// <returns>The decoded data</returns>
+    public string GetString(byte[] data)
+    {
+        return Convert.ToBase64String(data);
+    }
+
+    /// <summary>
+    /// Decodes the given data from a byte array
+    /// </summary>
+    /// <param name="data">The data to decode</param>
+    /// <param name="index">The index to start at</param>
+    /// <param name="count">The count of the data to decode</param>
+    /// <returns>The returned data</returns>
+    public string GetString(byte[] data, int index, int count)
+    {
+        return Convert.ToBase64String(data, index, count);
+    }
+}

--- a/src/PalWorld.Networking/Encoders/IEncoderService.cs
+++ b/src/PalWorld.Networking/Encoders/IEncoderService.cs
@@ -1,0 +1,31 @@
+﻿
+namespace PalWorld.Networking;
+
+/// <summary>
+/// Represents a service that can encode and decode packet data
+/// </summary>
+public interface IEncoderService
+{
+    /// <summary>
+    /// Encodes the given data into a byte array
+    /// </summary>
+    /// <param name="data">The data to be encoded</param>
+    /// <returns>The encoded data</returns>
+    byte[] GetBytes(string data);
+
+    /// <summary>
+    /// Decodes the given data from a byte array
+    /// </summary>
+    /// <param name="data">The data to decode</param>
+    /// <returns>The decoded data</returns>
+    string GetString(byte[] data);
+
+    /// <summary>
+    /// Decodes the given data from a byte array
+    /// </summary>
+    /// <param name="data">The data to decode</param>
+    /// <param name="index">The index to start at</param>
+    /// <param name="count">The count of the data to decode</param>
+    /// <returns>The returned data</returns>
+    string GetString(byte[] data, int index, int count);
+}

--- a/src/PalWorld.Networking/Encoders/PalEncoders.cs
+++ b/src/PalWorld.Networking/Encoders/PalEncoders.cs
@@ -8,25 +8,25 @@ public static class PalEncoders
     /// <summary>
     /// The default encoder used by the library
     /// </summary>
-    public static IEncoderService Default { get; } = Utf8!;
+    public static IEncoderService Default => Utf8;
 
     /// <summary>
     /// The UTF-8 encoder
     /// </summary>
-    public static IEncoderService Utf8 { get; } = new Utf8EncoderService();
+    public static IEncoderService Utf8 => new Utf8EncoderService();
 
     /// <summary>
     /// The UTF-16 encoder
     /// </summary>
-    public static IEncoderService Utf16 { get; } = new Utf16EncoderService();
+    public static IEncoderService Utf16 => new Utf16EncoderService();
 
     /// <summary>
     /// The UTF-32 encoder
     /// </summary>
-    public static IEncoderService Utf32 { get; } = new Utf32EncoderService();
+    public static IEncoderService Utf32 => new Utf32EncoderService();
 
     /// <summary>
     /// The Base64 encoder
     /// </summary>
-    public static IEncoderService Base64 { get; } = new Base64EncoderService();
+    public static IEncoderService Base64 => new Base64EncoderService();
 }

--- a/src/PalWorld.Networking/Encoders/PalEncoders.cs
+++ b/src/PalWorld.Networking/Encoders/PalEncoders.cs
@@ -1,0 +1,32 @@
+﻿namespace PalWorld.Networking;
+
+/// <summary>
+/// Represents the various encoders included with the library
+/// </summary>
+public static class PalEncoders
+{
+    /// <summary>
+    /// The default encoder used by the library
+    /// </summary>
+    public static IEncoderService Default { get; } = Utf8!;
+
+    /// <summary>
+    /// The UTF-8 encoder
+    /// </summary>
+    public static IEncoderService Utf8 { get; } = new Utf8EncoderService();
+
+    /// <summary>
+    /// The UTF-16 encoder
+    /// </summary>
+    public static IEncoderService Utf16 { get; } = new Utf16EncoderService();
+
+    /// <summary>
+    /// The UTF-32 encoder
+    /// </summary>
+    public static IEncoderService Utf32 { get; } = new Utf32EncoderService();
+
+    /// <summary>
+    /// The Base64 encoder
+    /// </summary>
+    public static IEncoderService Base64 { get; } = new Base64EncoderService();
+}

--- a/src/PalWorld.Networking/Encoders/SystemEncoderService.cs
+++ b/src/PalWorld.Networking/Encoders/SystemEncoderService.cs
@@ -1,0 +1,60 @@
+﻿namespace PalWorld.Networking;
+
+/// <summary>
+/// Represents an encoder service that uses a specific <see cref="Encoding"/> for encoding and decoding
+/// </summary>
+/// <param name="_encoding"></param>
+public abstract class SystemEncoderService(Encoding _encoding) : IEncoderService
+{
+    /// <summary>
+    /// The <see cref="Encoding"/> to use for encoding and decoding
+    /// </summary>
+    public virtual Encoding Encoding { get; } = _encoding;
+
+    /// <summary>
+    /// Encodes the given data into a byte array
+    /// </summary>
+    /// <param name="data">The data to be encoded</param>
+    /// <returns>The encoded data</returns>
+    public virtual byte[] GetBytes(string data)
+    {
+        return Encoding.GetBytes(data);
+    }
+
+    /// <summary>
+    /// Encodes the given data into a byte array
+    /// </summary>
+    /// <param name="data">The data to be encoded</param>
+    /// <returns>The encoded data</returns>
+    public virtual string GetString(byte[] data)
+    {
+        return Encoding.GetString(data);
+    }
+
+    /// <summary>
+    /// Decodes the given data from a byte array
+    /// </summary>
+    /// <param name="data">The data to decode</param>
+    /// <param name="index">The index to start at</param>
+    /// <param name="count">The count of the data to decode</param>
+    /// <returns>The returned data</returns>
+    public virtual string GetString(byte[] data, int index, int count)
+    {
+        return Encoding.GetString(data, index, count);
+    }
+}
+
+/// <summary>
+/// Represents an encoder service that uses UTF-8 for encoding and decoding
+/// </summary>
+public class Utf8EncoderService() : SystemEncoderService(Encoding.UTF8) { }
+
+/// <summary>
+/// Represents an encoder service that uses UTF-16 for encoding and decoding
+/// </summary>
+public class Utf16EncoderService() : SystemEncoderService(Encoding.Unicode) { }
+
+/// <summary>
+/// Represents an encoder service that uses UTF-32 for encoding and decoding
+/// </summary>
+public class Utf32EncoderService() : SystemEncoderService(Encoding.UTF32) { }

--- a/src/PalWorld.Networking/Extensions.cs
+++ b/src/PalWorld.Networking/Extensions.cs
@@ -8,16 +8,71 @@ public static class Extensions
     /// <summary>
     /// Polyfill of .net 8's Task.WaitAsync
     /// </summary>
-    /// <typeparam name="T">The type of task</typeparam>
-    /// <param name="task">The task operation</param>
-    /// <param name="timeoutMs">How long to wait before timing out</param>
-    /// <returns>The value of the task</returns>
-    /// <exception cref="TimeoutException">Thrown if the timeout occurs</exception>
-    public static async Task<T> WaitTimeout<T>(this Task<T> task, int timeoutMs)
+    /// <typeparam name="T">The type of return result from the task</typeparam>
+    /// <param name="task">The task for which to wait on until completion.</param>
+    /// <param name="timeout">The timeout after which the <see cref="Task"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
+    /// <returns>The value of the task that completed before the timeout occurred</returns>
+    /// <exception cref="ArgumentNullException">The <paramref name="task"/> argument is null</exception>
+    /// <exception cref="ArgumentOutOfRangeException">The <paramref name="timeout"/> is negative without being <see cref="Timeout.InfiniteTimeSpan"/></exception>
+    /// <exception cref="TimeoutException">Thrown if a timeout occurs</exception>
+    /// <exception cref="TaskCanceledException">Thrown if the <paramref name="task"/> is cancelled</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the <paramref name="task"/> is faulted but no exception is provided</exception>
+    public static async Task<T> WaitTimeout<T>(this Task<T> task, TimeSpan timeout)
     {
-        var operation = await Task.WhenAny(task, Task.Delay(timeoutMs));
-        if (operation == task) return await task;
+        //Most of this code was inspired by: https://github.com/dotnet/runtime/blob/204b10988f8adb12d4bd3fc7d313d41aeef19e39/src/libraries/Microsoft.Bcl.TimeProvider/src/System/Threading/Tasks/TimeProviderTaskExtensions.cs#L28
 
-        throw new TimeoutException();
+        //Ensure parameters are valid
+        if (task is null) 
+            throw new ArgumentNullException(nameof(task), "Task cannot be null");
+
+        if (timeout != Timeout.InfiniteTimeSpan && timeout < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout), "Timeout must be non-negative");
+
+        //Task already completed? Return it, no need to do anything else
+        if (task.IsCompleted) return task.Result;
+        //Timespan is infinite? Await the underlying task.
+        if (timeout == Timeout.InfiniteTimeSpan) return await task;
+        //Timespan is zero? Throw a timeout exception.
+        if (timeout == TimeSpan.Zero) throw new TimeoutException("Timespan was zero");
+
+        //Create a cancellation token for cancelling the delay if the task resolves
+        using var delayCancelSource = new CancellationTokenSource();
+        //Create the delay for the timeout.
+        var delay = Task.Delay(timeout, delayCancelSource.Token);
+
+        try
+        {
+            //Get the first task to complete
+            var first = await Task.WhenAny(task, delay);
+            //If the first task is the target, cancel the delay and return the result
+            if (first == task)
+            {
+                delayCancelSource.Cancel();
+                return task.Result;
+            }
+
+            //Throw the timeout exception
+            throw new TimeoutException("Task did not complete within the specified timeout");
+        }
+        catch (OperationCanceledException)
+        {
+            //If the target task was cancelled, re-throw that exception
+            if (task.IsCanceled) throw new TaskCanceledException(task);
+            //If the target task was completed, but something went wrong with the delay (can be a race condition), return the result
+            if (task.IsCompleted) return task.Result;
+            //If the target task was faulted, throw the exception
+            if (task.IsFaulted) throw task.Exception ?? throw new InvalidOperationException("Task faulted but has no exception");
+            //Re-throw the cancellation in the event something went wrong with the delay task
+            throw;
+        }
     }
+
+    /// <summary>
+    /// Wrapping provider for <see cref="WaitTimeout{T}(Task{T}, TimeSpan)"/>
+    /// </summary>
+    /// <typeparam name="T">The type of return result from the task</typeparam>
+    /// <param name="task">The task for which to wait on until completion.</param>
+    /// <param name="timeout">The timeout (in milliseconds) after which the <see cref="Task"/> should be faulted with a <see cref="TimeoutException"/> if it hasn't otherwise completed.</param>
+    /// <returns>The value of the task that completed before the timeout occurred</returns>
+    public static async Task<T> WaitTimeout<T>(this Task<T> task, int timeout) => await task.WaitTimeout(TimeSpan.FromMilliseconds(timeout));
 }

--- a/src/PalWorld.Networking/PalWorld.Networking.csproj
+++ b/src/PalWorld.Networking/PalWorld.Networking.csproj
@@ -11,8 +11,8 @@
 		<PackageIcon>icon.jpg</PackageIcon>
 		<RepositoryUrl>https://github.com/calico-crusade/palworld-rcon-sharp</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<PackageTags>PalWorld;RCON;CardboardBox;Cardboard;Pokemon;</PackageTags>
-		<Version>1.0.2</Version>
+		<PackageTags>PalWorld;RCON;CardboardBox;Cardboard;Pokemon;PalGuard;Antiguard</PackageTags>
+		<Version>1.0.3</Version>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<LangVersion>latest</LangVersion>

--- a/src/PalWorld.Networking/PersistentRconClient.cs
+++ b/src/PalWorld.Networking/PersistentRconClient.cs
@@ -28,7 +28,7 @@ public class PersistentRconClient(
     string password, 
     int timeoutSec = 20,
     int maxRetries = 3,
-    Encoding? encoding = null) : IPersistentRconClient
+    IEncoderService? encoding = null) : IPersistentRconClient
 {
     /// <summary>
     /// Triggered when an unhandled exception occurs

--- a/src/PalWorld.Networking/RconClient.cs
+++ b/src/PalWorld.Networking/RconClient.cs
@@ -62,7 +62,7 @@ public class RconClient : IRconClient
     /// <summary>
     /// The default encoding to use for the packet body content
     /// </summary>
-    private static readonly Encoding _defaultEncoding = Encoding.UTF8;
+    private static readonly IEncoderService _defaultEncoding = PalEncoders.Default;
 
     #region Events
     /// <summary>
@@ -153,7 +153,7 @@ public class RconClient : IRconClient
     /// <param name="password">The Admin password for the server</param>
     /// <param name="cmdTimeoutSec">How long to wait before considering a command ignored</param>
     /// <param name="encoder">The encoding to use for the packet body content</param>
-    public RconClient(string host, int port, string password, int cmdTimeoutSec = 20, Encoding? encoder = null)
+    public RconClient(string host, int port, string password, int cmdTimeoutSec = 20, IEncoderService? encoder = null)
     {
         _password = password;
         _cmdTimeoutSec = cmdTimeoutSec;

--- a/src/PalWorld.Networking/ResponseParser.cs
+++ b/src/PalWorld.Networking/ResponseParser.cs
@@ -8,6 +8,11 @@ using Models;
 public interface IResponseParser
 {
     /// <summary>
+    /// The instance of the RCON sender
+    /// </summary>
+    IRconSender Instance { get; }
+
+    /// <summary>
     /// Gets a list of players currently in the game.
     /// </summary>
     /// <returns>The currently active players</returns>
@@ -22,6 +27,8 @@ public interface IResponseParser
 
 internal class ResponseParser(IRconSender _rcon) : IResponseParser
 {
+    public IRconSender Instance => _rcon;
+
     public async Task<PalPlayer[]> GetPlayers()
     {
         var response = await _rcon.SendShowPlayers();


### PR DESCRIPTION
This should fix issue #2 , takes inspiration from #3 

* Adds Base64 support for PalGuard compatibility. 
* Adds Base16 and Base32 support for potential future compatibility with RCON changes in the future
* Examples in ReadMe for how to enable it.

Unfortunately, I don't have a windows dedicated server to test it thoroughly. 

Here is a description of the changes:
* Added a service template for encoding support called `IEncoderService` the has 3 methods for dealing with byte[] <-> string conversions
* Added a default service implementation for standard `Encoding.*` support: `SystemEncoderService`.
  * Default implementation for UTF8:  `Utf8EncoderService` (in `SystemEncoderService.cs`)
  * Default implementation for UTF16: `Utf16EncoderService` (in `SystemEncoderService.cs`)
  * Default implementation for UTF32: `Utf32EncoderService` (in `SystemEncoderService.cs`)
  * Default implementation for Base64: `Base64EncoderService` (in `Base64EncoderService.cs`)
* Add `Encoding.*` like class for default implementations: `PalEncoders.cs`
  * `PalEncoders.Default` is a reference to `PalEncoders.Utf8` since the default encoding is currently UTF8 
* Changed the `encoder` parameter on all `IRconSender` concrete implementations to support the new service instead of `Encoder`
* Added exception for Authentication Packets since PalGuard doesn't mess with those. 

Use of these changes can be seen in the following example (from modified readme):
```csharp
using PalWorld.Networking;

var host = "192.168.1.69";
var port = 25575;
var pass = "S0mep4ssw0rd$";
var encoding = PalEncoders.Base64; //or PalEncoders.Utf16, PalEncoders.Utf32

//Regular client
var client = new RconClient(host, port, pass, encoder: encoding);
//Persistent client
var persistentClient = new PersistentRconClient(host, port, pass, encoder: encoding);
```